### PR TITLE
[SITE-6002] Fix CodeQL alerts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Test
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds explicit `permissions: contents: read` to the test workflow. Without a permissions block, the workflow runs with the default token permissions, which is broader than necessary. This resolves the CodeQL `missing-workflow-permissions` alert.

## Test plan

- [ ] Verify the test workflow still passes on this PR
- [ ] Confirm CodeQL alert is resolved